### PR TITLE
Allowing whole rows to be wrapped in a card or container.

### DIFF
--- a/lib/src/manager/pluto_grid_state_manager.dart
+++ b/lib/src/manager/pluto_grid_state_manager.dart
@@ -208,11 +208,13 @@ class PlutoGridStateChangeNotifier extends PlutoChangeNotifier
 /// ```
 /// {@endtemplate}
 class PlutoGridStateManager extends PlutoGridStateChangeNotifier {
+  final rowWrapper;
   PlutoGridStateManager({
     required super.columns,
     required super.rows,
     required super.gridFocusNode,
     required super.scroll,
+    this.rowWrapper,
     super.columnGroups,
     super.onChanged,
     super.onSelected,

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -54,10 +54,12 @@ typedef PlutoRowColorCallback = Color Function(
 /// and option selection used inside [PlutoGrid] are created with the API provided outside of [PlutoGrid].
 /// Also, the popup to set the filter or column inside the grid is implemented through the setting of [PlutoGrid].
 class PlutoGrid extends PlutoStatefulWidget {
+  final rowWrapper;
   const PlutoGrid({
     super.key,
     required this.columns,
     required this.rows,
+    this.rowWrapper,
     this.columnGroups,
     this.onLoaded,
     this.onChanged,
@@ -500,6 +502,7 @@ class PlutoGridState extends PlutoStateWithChange<PlutoGrid> {
     _stateManager = PlutoGridStateManager(
       columns: widget.columns,
       rows: widget.rows,
+      rowWrapper: widget.rowWrapper,
       gridFocusNode: _gridFocusNode,
       scroll: PlutoGridScrollController(
         vertical: _verticalScroll,
@@ -923,8 +926,7 @@ class PlutoGridLayoutDelegate extends MultiChildLayoutDelegate {
         BoxConstraints.loose(size),
       );
 
-      final double posX =
-          isLTR ? size.width - s.width + gridBorderWidth : 0;
+      final double posX = isLTR ? size.width - s.width + gridBorderWidth : 0;
 
       positionChild(
         _StackName.rightFrozenColumns,
@@ -1046,9 +1048,8 @@ class PlutoGridLayoutDelegate extends MultiChildLayoutDelegate {
 
     if (hasChild(_StackName.leftFrozenRows)) {
       final double offset = isLTR ? bodyLeftOffset : bodyRightOffset;
-      final double posX = isLTR
-          ? 0
-          : size.width - bodyRightOffset + gridBorderWidth;
+      final double posX =
+          isLTR ? 0 : size.width - bodyRightOffset + gridBorderWidth;
 
       layoutChild(
         _StackName.leftFrozenRows,
@@ -1068,9 +1069,8 @@ class PlutoGridLayoutDelegate extends MultiChildLayoutDelegate {
 
     if (hasChild(_StackName.leftFrozenColumnFooters)) {
       final double offset = isLTR ? bodyLeftOffset : bodyRightOffset;
-      final double posX = isLTR
-          ? 0
-          : size.width - bodyRightOffset + gridBorderWidth;
+      final double posX =
+          isLTR ? 0 : size.width - bodyRightOffset + gridBorderWidth;
 
       layoutChild(
         _StackName.leftFrozenColumnFooters,
@@ -1087,9 +1087,8 @@ class PlutoGridLayoutDelegate extends MultiChildLayoutDelegate {
 
     if (hasChild(_StackName.rightFrozenRows)) {
       final double offset = isLTR ? bodyRightOffset : bodyLeftOffset;
-      final double posX = isLTR
-          ? size.width - bodyRightOffset + gridBorderWidth
-          : 0;
+      final double posX =
+          isLTR ? size.width - bodyRightOffset + gridBorderWidth : 0;
 
       layoutChild(
         _StackName.rightFrozenRows,
@@ -1114,8 +1113,7 @@ class PlutoGridLayoutDelegate extends MultiChildLayoutDelegate {
         BoxConstraints.loose(Size(offset, size.height)),
       );
 
-      final double posX =
-          isLTR ? size.width - s.width + gridBorderWidth : 0;
+      final double posX = isLTR ? size.width - s.width + gridBorderWidth : 0;
 
       positionChild(
         _StackName.rightFrozenColumnFooters,

--- a/lib/src/ui/pluto_body_rows.dart
+++ b/lib/src/ui/pluto_body_rows.dart
@@ -104,14 +104,28 @@ class PlutoBodyRowsState extends PlutoStateWithChange<PlutoBodyRows> {
             itemExtent: stateManager.rowTotalHeight,
             addRepaintBoundaries: false,
             itemBuilder: (ctx, i) {
-              return PlutoBaseRow(
-                key: ValueKey('body_row_${_rows[i].key}'),
-                rowIdx: i,
-                row: _rows[i],
-                columns: _columns,
-                stateManager: stateManager,
-                visibilityLayout: true,
-              );
+              // if statemanager.rowWrapper != null
+              // wrap the pluto base row with the rowWrapper
+              if (stateManager.rowWrapper != null)
+                return stateManager.rowWrapper!(
+                    _rows[i],
+                    PlutoBaseRow(
+                      key: ValueKey('body_row_${_rows[i].key}'),
+                      rowIdx: i,
+                      row: _rows[i],
+                      columns: _columns,
+                      stateManager: stateManager,
+                      visibilityLayout: true,
+                    ));
+              else
+                return PlutoBaseRow(
+                  key: ValueKey('body_row_${_rows[i].key}'),
+                  rowIdx: i,
+                  row: _rows[i],
+                  columns: _columns,
+                  stateManager: stateManager,
+                  visibilityLayout: true,
+                );
             },
           ),
         ),


### PR DESCRIPTION
rowWrapper 

optionally wrap the rows together for a different look

PlutoGrid(
rowWrapper: (PlutoRow row, Widget child) {

return Card(
child: child),
};
)