### PR TITLE
bump intl to 0.19

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   # Follows the intl version included in Flutter.
   # https://github.com/flutter/flutter/blob/84a1e904f44f9b0e9c4510138010edcc653163f8/packages/flutter_localizations/pubspec.yaml#L11
-  intl: ^0.18.1
+  intl: ^0.19.0
   rxdart: ^0.27.7
   collection: ^1.18.0
 


### PR DESCRIPTION
Since flutter 3.22, version 0.19 is now the default