### PR TITLE
Added filterWidgetBuilder

### DIFF
--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -245,6 +245,7 @@ class PlutoColumn {
     this.filterHintText,
     this.filterHintTextColor,
     this.filterSuffixIcon,
+    @Deprecated("Use new filterWidgetBuilder to provide some parameters")
     this.filterWidget,
     this.enableHideColumnMenuItem = true,
     this.enableSetColumnsMenuItem = true,

--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -186,7 +186,16 @@ class PlutoColumn {
   Icon? filterSuffixIcon;
 
   ///Set custom widget
+  @Deprecated("Use new filterWidgetBuilder to provide some parameters")
   Widget? filterWidget;
+
+  Widget Function(
+    FocusNode focusNode,
+    TextEditingController controller,
+    bool enabled,
+    void Function(String changed) handleOnChanged,
+    PlutoGridStateManager stateManager,
+  )? filterWidgetBuilder;
 
   /// Displays Hide column menu in the column context menu.
   /// Valid only when [enableContextMenu] is activated.
@@ -242,6 +251,7 @@ class PlutoColumn {
     this.enableAutoEditing = false,
     this.enableEditingMode = true,
     this.hide = false,
+    this.filterWidgetBuilder,
   })  : _key = UniqueKey(),
         _checkReadOnly = checkReadOnly;
 

--- a/lib/src/ui/columns/pluto_column_filter.dart
+++ b/lib/src/ui/columns/pluto_column_filter.dart
@@ -254,7 +254,8 @@ class PlutoColumnFilterState extends PlutoStateWithChange<PlutoColumnFilter> {
         ),
         child: Padding(
           padding: _padding,
-          child: widget.column.filterWidget ??
+          child: widget.column.filterWidgetBuilder?.call(_focusNode,
+                  _controller, _enabled, _handleOnChanged, stateManager) ??
               TextField(
                 focusNode: _focusNode,
                 controller: _controller,

--- a/lib/src/ui/columns/pluto_column_filter.dart
+++ b/lib/src/ui/columns/pluto_column_filter.dart
@@ -254,8 +254,9 @@ class PlutoColumnFilterState extends PlutoStateWithChange<PlutoColumnFilter> {
         ),
         child: Padding(
           padding: _padding,
-          child: widget.column.filterWidgetBuilder?.call(_focusNode,
-                  _controller, _enabled, _handleOnChanged, stateManager) ??
+          child: widget.column.filterWidget ??
+              widget.column.filterWidgetBuilder?.call(_focusNode, _controller,
+                  _enabled, _handleOnChanged, stateManager) ??
               TextField(
                 focusNode: _focusNode,
                 controller: _controller,

--- a/packages/pluto_grid_plus_export/example/pubspec.yaml
+++ b/packages/pluto_grid_plus_export/example/pubspec.yaml
@@ -29,7 +29,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  pluto_grid_plus: 8.4.1
+  pluto_grid_plus: 8.4.2
   pluto_grid_plus_export:
     path: ../
   file_saver: ^0.2.12


### PR DESCRIPTION


While trying to customize our filters with the `filterWidget` we ran into some problems:
- Input fields could either not be focused, or would not take any user input
- We can't access the data in the column

I have deprecated the filterWidget in PlutoColumn and instead added filterWidgetBuilder

This gives the developer the option to add custom filters widgets to the PlutoColumns.
Below some examples of this being used in a client test project.

![image](https://github.com/user-attachments/assets/08ae187c-134b-4448-a1bc-7d48ac252f67)
```dart
TextField(
      decoration: IFMInputDecoration().copyWith(
        hintText: "contains".tr,
        // contentPadding: const EdgeInsets.all(8),
        hintStyle: const IFMTextStyle().copyWith(
          color: grey,
          fontSize: filterFontSize,
        ),
        alignLabelWithHint: true,
      ),
      style: const IFMTextStyle().copyWith(
        color: grey,
        fontSize: filterFontSize,
      ),
      onChanged: handleOnChanged,
      focusNode: focusNode,
      controller: controller,
      enabled: enabled,
    );
```

The below dropdown is generated from the data available in the column itself
![image](https://github.com/user-attachments/assets/6fdabafc-d94b-4b05-8083-d66004027291)
```dart
final list = stateManager.refRows.originalList
      .map((row) => (row.cells[field]?.value as String?) ?? "")
      .toSet()
      .toList();

DropdownMenu(
      expandedInsets: EdgeInsets.zero,
      hintText: "choose".tr,
      controller: controller,
      focusNode: focusNode,
      enabled: enabled,
      onSelected: (value) {
        handleOnChanged.call(value ?? "");
      },
      textStyle: const IFMTextStyle().copyWith(
        fontSize: filterFontSize,
      ),
      dropdownMenuEntries: [
        ...list.map(
          (e) => DropdownMenuEntry(
            value: e,
            label: e,
          ),
        ),
      ],
    );
```

These changes would allow each type of column to have a it's own unique filter when necessary
(no working example for from-to yet)
![image](https://github.com/user-attachments/assets/75ac64d4-f0cd-432b-a37e-8b83e31f8ec9)


