### PR TITLE
made average and sum aggregates ignore null values

### DIFF
--- a/lib/src/helper/pluto_aggregate_helper.dart
+++ b/lib/src/helper/pluto_aggregate_helper.dart
@@ -1,5 +1,5 @@
 import 'package:collection/collection.dart'
-    show IterableNumberExtension, IterableExtension;
+    show IterableExtension, IterableNullableExtension, IterableNumberExtension;
 import 'package:pluto_grid_plus/pluto_grid_plus.dart';
 
 class PlutoAggregateHelper {
@@ -19,9 +19,11 @@ class PlutoAggregateHelper {
         ? rows.where((row) => filter(row.cells[column.field]!))
         : rows;
 
-    final Iterable<num> numbers = foundItems.map(
-      (e) => e.cells[column.field]!.value,
-    );
+    final Iterable<num> numbers = foundItems
+        .map(
+          (e) => e.cells[column.field]?.value as num?,
+        )
+        .whereNotNull();
 
     return numberColumn.toNumber(numberColumn.applyFormat(numbers.sum));
   }
@@ -42,9 +44,11 @@ class PlutoAggregateHelper {
         ? rows.where((row) => filter(row.cells[column.field]!))
         : rows;
 
-    final Iterable<num> numbers = foundItems.map(
-      (e) => e.cells[column.field]!.value,
-    );
+    final Iterable<num> numbers = foundItems
+        .map(
+          (e) => e.cells[column.field]?.value as num?,
+        )
+        .whereNotNull();
 
     return numberColumn.toNumber(numberColumn.applyFormat(numbers.average));
   }

--- a/lib/src/helper/pluto_aggregate_helper.dart
+++ b/lib/src/helper/pluto_aggregate_helper.dart
@@ -3,7 +3,7 @@ import 'package:collection/collection.dart'
 import 'package:pluto_grid_plus/pluto_grid_plus.dart';
 
 class PlutoAggregateHelper {
-  static num sum({
+  static num? sum({
     required Iterable<PlutoRow> rows,
     required PlutoColumn column,
     PlutoAggregateFilter? filter,
@@ -25,10 +25,12 @@ class PlutoAggregateHelper {
         )
         .whereNotNull();
 
-    return numberColumn.toNumber(numberColumn.applyFormat(numbers.sum));
+    return numbers.isNotEmpty
+        ? numberColumn.toNumber(numberColumn.applyFormat(numbers.sum))
+        : null;
   }
 
-  static num average({
+  static num? average({
     required Iterable<PlutoRow> rows,
     required PlutoColumn column,
     PlutoAggregateFilter? filter,
@@ -50,7 +52,9 @@ class PlutoAggregateHelper {
         )
         .whereNotNull();
 
-    return numberColumn.toNumber(numberColumn.applyFormat(numbers.average));
+    return numbers.isNotEmpty
+        ? numberColumn.toNumber(numberColumn.applyFormat(numbers.average))
+        : null;
   }
 
   static num? min({


### PR DESCRIPTION
Number columns where a value can be null (unknown != 0) would give an error while calculating the average/sum of the column in the footer aggregate. 

This fix ignores these null values when calculating 