### PR TITLE
Added Null throw to signal field isn't defined

### DIFF
--- a/lib/src/manager/pluto_grid_state_manager.dart
+++ b/lib/src/manager/pluto_grid_state_manager.dart
@@ -588,8 +588,6 @@ class _ApplyCellForSetColumnRow implements _Apply {
           ..setColumn(element)
           ..setRow(row);
       }
-    } on NullThrownError catch (e) {
-      throw 'NullThrownError occurred: ${e.toString()}';
     } catch (e) {
       throw 'An error occurred: ${e.toString()}';
     }

--- a/lib/src/manager/pluto_grid_state_manager.dart
+++ b/lib/src/manager/pluto_grid_state_manager.dart
@@ -589,7 +589,7 @@ class _ApplyCellForSetColumnRow implements _Apply {
           ..setRow(row);
       }
     } catch (e) {
-      throw 'An error occurred: ${e.toString()}';
+      rethrow;
     }
   }
 }

--- a/lib/src/manager/pluto_grid_state_manager.dart
+++ b/lib/src/manager/pluto_grid_state_manager.dart
@@ -582,10 +582,16 @@ class _ApplyCellForSetColumnRow implements _Apply {
       return;
     }
 
-    for (var element in refColumns) {
-      row.cells[element.field]!
-        ..setColumn(element)
-        ..setRow(row);
+    try {
+      for (var element in refColumns) {
+        row.cells[element.field]!
+          ..setColumn(element)
+          ..setRow(row);
+      }
+    } on NullThrownError catch (e) {
+      throw 'NullThrownError occurred: ${e.toString()}';
+    } catch (e) {
+      throw 'An error occurred: ${e.toString()}';
     }
   }
 }


### PR DESCRIPTION
Not sure if try catch is welcomed, but I stumbled upon:
`null check operator used on a null value` and took a while to debug and find out that it was a null check operator within `state_grid_manager`.

If no try catch I suppose we could do something like:
```dart
for (final ref in refColumns){
   if(ref.field == null) {
   //...
   }
}
// rest of code
```