### PR TITLE
Manually detect doubleTaps on desktop platform to eliminate delay

### DIFF
--- a/lib/src/helper/pluto_double_tap_detector.dart
+++ b/lib/src/helper/pluto_double_tap_detector.dart
@@ -1,0 +1,24 @@
+import 'package:pluto_grid_plus/pluto_grid_plus.dart';
+
+class PlutoDoubleTapDetector {
+  static PlutoCell? _prevTappedCell;
+  static int _lastTap = DateTime.now().millisecondsSinceEpoch;
+  static int _consecutiveTaps = 1;
+
+  static bool isDoubleTap(PlutoCell cell) {
+    int now = DateTime.now().millisecondsSinceEpoch;
+    bool doubleTap = false;
+    if (now - _lastTap < 300) {
+      _consecutiveTaps++;
+      if (_consecutiveTaps >= 2 && _prevTappedCell == cell) {
+        doubleTap = true;
+      }
+    } else {
+      _consecutiveTaps = 1;
+      doubleTap = false;
+    }
+    _lastTap = now;
+    _prevTappedCell = cell;
+    return doubleTap;
+  }
+}

--- a/lib/src/ui/pluto_base_cell.dart
+++ b/lib/src/ui/pluto_base_cell.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pluto_grid_plus/pluto_grid_plus.dart';
+import 'package:pluto_grid_plus/src/helper/platform_helper.dart';
+import 'package:pluto_grid_plus/src/helper/pluto_double_tap_detector.dart';
 
 import 'ui.dart';
 
@@ -46,6 +48,12 @@ class PlutoBaseCell extends StatelessWidget
   }
 
   void _handleOnTapUp(TapUpDetails details) {
+    if (PlatformHelper.isDesktop &&
+        PlutoDoubleTapDetector.isDoubleTap(cell) &&
+        stateManager.onRowDoubleTap != null) {
+      _handleOnDoubleTap();
+      return;
+    }
     _addGestureEvent(PlutoGridGestureType.onTapUp, details.globalPosition);
   }
 
@@ -94,6 +102,9 @@ class PlutoBaseCell extends StatelessWidget
   }
 
   void Function()? _onDoubleTapOrNull() {
+    if (PlatformHelper.isDesktop) {
+      return null;
+    }
     return stateManager.onRowDoubleTap == null ? null : _handleOnDoubleTap;
   }
 


### PR DESCRIPTION
This PR addresses #83.
As you can see below, manual detection of double taps inside of `onTapUp` removes the significant single tap delay which is caused by Flutter's doubleTap detection on desktop. There is currently an [issue](https://github.com/flutter/flutter/issues/106170) from 2 years ago that asks for a fix on the SDK level, however, it doesn't seem to be coming anytime soon. So I think a workaround for this issue is the best course of action for now.


## Before
![before](https://github.com/user-attachments/assets/7b9bf2d8-9c7a-454a-bcde-4daa42586f1c)

## After
![after](https://github.com/user-attachments/assets/9456b009-798c-4031-9bdd-6922bf8d1a6a)
