### PR TITLE
Add PlutoGridRowSelectionCheckBehavior

### DIFF
--- a/lib/src/manager/state/grid_state.dart
+++ b/lib/src/manager/state/grid_state.dart
@@ -195,6 +195,7 @@ mixin GridState implements IPlutoGridState {
 
   @override
   void handleOnSelected() {
+    _handleSelectCheckRowBehavior();
     if (mode.isSelectMode == true && onSelected != null) {
       onSelected!(
         PlutoGridOnSelectedEvent(
@@ -204,6 +205,52 @@ mixin GridState implements IPlutoGridState {
           selectedRows: mode.isMultiSelectMode ? currentSelectingRows : null,
         ),
       );
+    }
+  }
+
+  void _handleSelectCheckRowBehavior() {
+    final stateManager = eventManager?.stateManager;
+    if (currentRow == null || stateManager == null) return;
+    final checkedRowsViaSelect = stateManager.checkedRowsViaSelect;
+    switch (configuration.rowSelectionCheckBoxBehavior) {
+      case PlutoGridRowSelectionCheckBoxBehavior.none:
+        break;
+      case PlutoGridRowSelectionCheckBoxBehavior.checkRow:
+        stateManager.setRowChecked(currentRow!, true, checkedViaSelect: true);
+        break;
+      case PlutoGridRowSelectionCheckBoxBehavior.toggleCheckRow:
+        if (checkedRowsViaSelect.contains(currentRow)) {
+          stateManager.setRowChecked(
+            currentRow!,
+            (!(currentRow?.checked ?? false)),
+            checkedViaSelect: true,
+          );
+        } else {
+          eventManager!.stateManager.setRowChecked(
+            currentRow!,
+            (!(currentRow?.checked ?? true)),
+            checkedViaSelect: true,
+          );
+        }
+        break;
+      case PlutoGridRowSelectionCheckBoxBehavior.singleRowCheck:
+        for (var row in checkedRowsViaSelect) {
+          row.setChecked(false);
+        }
+        currentRow!.setChecked(true, viaSelect: true);
+        stateManager.notifyListeners();
+        break;
+      case PlutoGridRowSelectionCheckBoxBehavior.toggleSingleRowCheck:
+        for (var row in checkedRowsViaSelect) {
+          row.setChecked(false);
+        }
+        if (checkedRowsViaSelect.contains(currentRow)) {
+          currentRow!.setChecked(false, viaSelect: false);
+        } else {
+          currentRow!.setChecked(true, viaSelect: true);
+        }
+        stateManager.notifyListeners();
+        break;
     }
   }
 

--- a/lib/src/manager/state/row_state.dart
+++ b/lib/src/manager/state/row_state.dart
@@ -24,6 +24,8 @@ abstract class IRowState {
 
   List<PlutoRow> get checkedRows;
 
+  List<PlutoRow> get checkedRowsViaSelect;
+
   List<PlutoRow> get unCheckedRows;
 
   bool get hasCheckedRow;
@@ -109,6 +111,10 @@ mixin RowState implements IPlutoGridState {
   List<PlutoRow> get checkedRows => refRows.where((row) => row.checked!).toList(
         growable: false,
       );
+
+  @override
+  List<PlutoRow> get checkedRowsViaSelect =>
+      checkedRows.where((row) => row.checkedViaSelect).toList(growable: false);
 
   @override
   List<PlutoRow> get unCheckedRows =>
@@ -218,10 +224,11 @@ mixin RowState implements IPlutoGridState {
 
   @override
   void setRowChecked(
-    PlutoRow row,
-    bool flag, {
-    bool notify = true,
-  }) {
+      PlutoRow row,
+      bool flag, {
+        bool notify = true,
+        bool checkedViaSelect = false,
+      }) {
     final findRow = refRows.firstWhereOrNull(
       (element) => element.key == row.key,
     );
@@ -230,7 +237,7 @@ mixin RowState implements IPlutoGridState {
       return;
     }
 
-    findRow.setChecked(flag);
+    findRow.setChecked(flag, viaSelect: checkedViaSelect);
 
     notifyListeners(notify, setRowChecked.hashCode);
   }

--- a/lib/src/model/pluto_row.dart
+++ b/lib/src/model/pluto_row.dart
@@ -28,6 +28,8 @@ class PlutoRow<T> {
 
   bool? _checked;
 
+  bool? _checkedViaSelect;
+
   PlutoRow? _parent;
 
   PlutoRowState _state;
@@ -68,6 +70,10 @@ class PlutoRow<T> {
   /// or PlutoStateManager.toggleAllRowChecked methods.
   bool? get checked {
     return type.isGroup ? _tristateCheckedRow : _checked;
+  }
+
+  bool get checkedViaSelect {
+    return (checked ?? false) && (_checkedViaSelect ?? false);
   }
 
   bool? get _tristateCheckedRow {
@@ -124,8 +130,9 @@ class PlutoRow<T> {
 
   void setData(T data) => this.data = data;
 
-  void setChecked(bool? flag) {
+  void setChecked(bool? flag, {bool viaSelect = false}) {
     _checked = flag;
+    _checkedViaSelect = viaSelect;
     if (type.isGroup) {
       for (final child in type.group.children) {
         child.setChecked(flag);

--- a/lib/src/pluto_grid_configuration.dart
+++ b/lib/src/pluto_grid_configuration.dart
@@ -11,6 +11,24 @@ class PlutoGridConfiguration {
   /// Moves the current cell when focus reaches the left or right edge in the edit state.
   final bool enableMoveHorizontalInEditing;
 
+  /// [PlutoGridRowSelectionCheckBoxBehavior.none]
+  /// Selecting a row does nothing to its checkbox
+  ///
+  /// [PlutoGridRowSelectionCheckBoxBehavior.checkRow]
+  /// Automatically enables the checkbox of the selected rows
+  ///
+  /// [PlutoGridRowSelectionCheckBoxBehavior.toggleCheckRow]
+  /// Automatically toggles the checkbox of the selected rows
+  ///
+  /// [PlutoGridRowSelectionCheckBoxBehavior.singleRowCheck]
+  /// Checks a selected row (if another row is checked via select, the previous one is unchecked)
+  ///
+  /// [PlutoGridRowSelectionCheckBoxBehavior.singleRowCheck]
+  /// Toggles the checkbox of a selected row (if another row is checked via select, the previous one is unchecked)
+  ///
+  /// Important: Only works with mode: PlutoGridMode.selectWithOneTap,
+  final PlutoGridRowSelectionCheckBoxBehavior rowSelectionCheckBoxBehavior;
+
   /// [PlutoEnterKeyAction.EditingAndMoveDown]
   /// It switches to the editing state, and moves down in the editing state.
   ///
@@ -76,6 +94,8 @@ class PlutoGridConfiguration {
   const PlutoGridConfiguration({
     this.enableMoveDownAfterSelecting = false,
     this.enableMoveHorizontalInEditing = false,
+    this.rowSelectionCheckBoxBehavior =
+        PlutoGridRowSelectionCheckBoxBehavior.none,
     this.enterKeyAction = PlutoGridEnterKeyAction.editingAndMoveDown,
     this.tabKeyAction = PlutoGridTabKeyAction.normal,
     this.shortcut = const PlutoGridShortcut(),
@@ -89,6 +109,8 @@ class PlutoGridConfiguration {
   const PlutoGridConfiguration.dark({
     this.enableMoveDownAfterSelecting = false,
     this.enableMoveHorizontalInEditing = false,
+    this.rowSelectionCheckBoxBehavior =
+        PlutoGridRowSelectionCheckBoxBehavior.none,
     this.enterKeyAction = PlutoGridEnterKeyAction.editingAndMoveDown,
     this.tabKeyAction = PlutoGridTabKeyAction.normal,
     this.shortcut = const PlutoGridShortcut(),
@@ -1757,6 +1779,19 @@ class PlutoGridLocaleText {
         minute,
         loadingText,
       ]);
+}
+
+enum PlutoGridRowSelectionCheckBoxBehavior {
+  /// Selecting a row does nothing to its checkbox
+  none,
+  /// Automatically enables the checkbox of the selected rows
+  checkRow,
+  /// Automatically toggles the checkbox value of the selected rows
+  toggleCheckRow,
+  /// Checks a selected row (if another row is selected via select, the previous one is unchecked)
+  singleRowCheck,
+  /// Toggle checks a selected (if another row is selected, the previous one is unchecked)
+  toggleSingleRowCheck,
 }
 
 /// Behavior of the Enter key when a cell is selected.

--- a/lib/src/pluto_grid_configuration.dart
+++ b/lib/src/pluto_grid_configuration.dart
@@ -21,10 +21,10 @@ class PlutoGridConfiguration {
   /// Automatically toggles the checkbox of the selected rows
   ///
   /// [PlutoGridRowSelectionCheckBoxBehavior.singleRowCheck]
-  /// Checks a selected row (if another row is checked via select, the previous one is unchecked)
+  /// Automatically enabels the checkbox of a selected row (if another row is checked via select, the previous one is unchecked)
   ///
   /// [PlutoGridRowSelectionCheckBoxBehavior.singleRowCheck]
-  /// Toggles the checkbox of a selected row (if another row is checked via select, the previous one is unchecked)
+  /// Automatically toggles the checkbox of a selected row (if another row is checked via select, the previous one is unchecked)
   ///
   /// Important: Only works with mode: PlutoGridMode.selectWithOneTap,
   final PlutoGridRowSelectionCheckBoxBehavior rowSelectionCheckBoxBehavior;
@@ -1786,11 +1786,11 @@ enum PlutoGridRowSelectionCheckBoxBehavior {
   none,
   /// Automatically enables the checkbox of the selected rows
   checkRow,
-  /// Automatically toggles the checkbox value of the selected rows
+  /// Automatically toggles the checkbox of the selected rows
   toggleCheckRow,
-  /// Checks a selected row (if another row is selected via select, the previous one is unchecked)
+  /// Automatically enabels the checkbox of a selected row (if another row is checked via select, the previous one is unchecked)
   singleRowCheck,
-  /// Toggle checks a selected (if another row is selected, the previous one is unchecked)
+  /// Automatically toggles the checkbox of a selected row (if another row is checked via select, the previous one is unchecked)
   toggleSingleRowCheck,
 }
 


### PR DESCRIPTION
This PR adds `PlutoGridRowSelectionCheckBoxBehavior` to the PlutoGrid configuration which allows for automatically enabling/disabling the check box of rows when a row is tapped (selected).
I think this is a pretty nice feature to have for those who primarily use `mode: PlutoGridMode.selectWithOneTap` and would like to provide a better UX by not forcing the user to use the checkbox to check/uncheck rows.


https://github.com/user-attachments/assets/66fc171b-37d1-47f9-a8ee-6061e0a06ec9

