### PR TITLE
feat: continue to _update infinity scroll if screen not filled

### DIFF
--- a/lib/src/plugin/pluto_infinity_scroll_rows.dart
+++ b/lib/src/plugin/pluto_infinity_scroll_rows.dart
@@ -199,6 +199,15 @@ class _PlutoInfinityScrollRowsState extends State<PlutoInfinityScrollRows> {
       _isFetching = false;
 
       _isLast = response.isLast;
+
+      if (!_isLast) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (scroll.position.maxScrollExtent == 0) {
+	    var lastRow = stateManager.rows.isNotEmpty ? stateManager.rows.last : null;
+            _update(lastRow);
+          }
+        });
+      }
     });
   }
 

--- a/lib/src/plugin/pluto_infinity_scroll_rows.dart
+++ b/lib/src/plugin/pluto_infinity_scroll_rows.dart
@@ -202,7 +202,7 @@ class _PlutoInfinityScrollRowsState extends State<PlutoInfinityScrollRows> {
 
       if (!_isLast) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (scroll.position.maxScrollExtent == 0) {
+          if (scroll.hasClients && scroll.position.maxScrollExtent == 0) {
 	    var lastRow = stateManager.rows.isNotEmpty ? stateManager.rows.last : null;
             _update(lastRow);
           }


### PR DESCRIPTION
### Context

`PlutoInfinityScrollRows` allows infinity scroll and `initialFetch=true` allows to fetch the data at first-post-frame.

However if the `fetch` was not designed to return enough row to fill the screen (i.e. returns 10 rows but the big screen device allows 40) then the user will think that the data is shorter than available.


### Solution 

The loading of data is done with `_update() > fetch()` and it should be called until the result's `isLast` is false OR if the bottom of the screen was reached.