### PR TITLE
Added missing parameter filterWidgetBuilder and onFilterSuffixTap

### DIFF
--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -191,6 +191,15 @@ class PlutoColumn {
   ///Set suffix icon for filter field
   Icon? filterSuffixIcon;
 
+  /// Set a custom on tap event for the filter suffix icon
+  Function(
+    FocusNode focusNode,
+    TextEditingController controller,
+    bool enabled,
+    void Function(String changed) handleOnChanged,
+    PlutoGridStateManager stateManager,
+  )? onFilterSuffixTap;
+
   ///Set custom widget
   @Deprecated("Use new filterWidgetBuilder to provide some parameters")
   Widget? filterWidget;
@@ -257,6 +266,8 @@ class PlutoColumn {
     this.filterSuffixIcon,
     @Deprecated("Use new filterWidgetBuilder to provide some parameters")
     this.filterWidget,
+    this.filterWidgetBuilder,
+    this.onFilterSuffixTap,
     this.enableHideColumnMenuItem = true,
     this.enableSetColumnsMenuItem = true,
     this.enableAutoEditing = false,

--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -182,36 +182,6 @@ class PlutoColumn {
   /// Valid only when [enableContextMenu] is activated.
   bool enableFilterMenuItem;
 
-  ///Set hint text for filter field
-  String? filterHintText;
-
-  ///Set hint text color for filter field
-  Color? filterHintTextColor;
-
-  ///Set suffix icon for filter field
-  Icon? filterSuffixIcon;
-
-  /// Set a custom on tap event for the filter suffix icon
-  Function(
-    FocusNode focusNode,
-    TextEditingController controller,
-    bool enabled,
-    void Function(String changed) handleOnChanged,
-    PlutoGridStateManager stateManager,
-  )? onFilterSuffixTap;
-
-  ///Set custom widget
-  @Deprecated("Use new filterWidgetBuilder to provide some parameters")
-  Widget? filterWidget;
-
-  Widget Function(
-    FocusNode focusNode,
-    TextEditingController controller,
-    bool enabled,
-    void Function(String changed) handleOnChanged,
-    PlutoGridStateManager stateManager,
-  )? filterWidgetBuilder;
-
   /// Displays Hide column menu in the column context menu.
   /// Valid only when [enableContextMenu] is activated.
   bool enableHideColumnMenuItem;
@@ -229,6 +199,9 @@ class PlutoColumn {
   bool hide;
 
   LinearGradient? backgroundGradient;
+
+  /// The widget of the filter column, this can be customized with the multiple constructors, defaults to a [PlutoFilterColumnWidgetDelegate.initial()]
+  PlutoFilterColumnWidgetDelegate? filterWidgetDelegate;
 
   PlutoColumn({
     required this.title,
@@ -261,18 +234,13 @@ class PlutoColumn {
     this.enableContextMenu = true,
     this.enableDropToResize = true,
     this.enableFilterMenuItem = true,
-    this.filterHintText,
-    this.filterHintTextColor,
-    this.filterSuffixIcon,
-    @Deprecated("Use new filterWidgetBuilder to provide some parameters")
-    this.filterWidget,
-    this.filterWidgetBuilder,
-    this.onFilterSuffixTap,
     this.enableHideColumnMenuItem = true,
     this.enableSetColumnsMenuItem = true,
     this.enableAutoEditing = false,
     this.enableEditingMode = true,
     this.hide = false,
+    this.filterWidgetDelegate =
+        const PlutoFilterColumnWidgetDelegate.textField(),
     this.disableRowCheckboxWhen,
   })  : _key = UniqueKey(),
         _checkReadOnly = checkReadOnly;
@@ -381,6 +349,60 @@ class PlutoColumn {
 
     return value.toString();
   }
+}
+
+class PlutoFilterColumnWidgetDelegate {
+  /// This is the default filter widget delegate
+  const PlutoFilterColumnWidgetDelegate.textField({
+    this.filterHintText,
+    this.filterHintTextColor,
+    this.filterSuffixIcon,
+    this.onFilterSuffixTap,
+    this.clearIcon = const Icon(Icons.clear),
+    this.onClear,
+  }) : filterWidgetBuilder = null;
+
+  /// If you don't want a custom widget
+  const PlutoFilterColumnWidgetDelegate.builder({
+    this.filterWidgetBuilder,
+  })  : filterSuffixIcon = null,
+        onFilterSuffixTap = null,
+        filterHintText = null,
+        filterHintTextColor = null,
+        clearIcon = const Icon(Icons.clear),
+        onClear = null;
+
+  ///Set hint text for filter field
+  final String? filterHintText;
+
+  ///Set hint text color for filter field
+  final Color? filterHintTextColor;
+
+  ///Set suffix icon for filter field
+  final Widget? filterSuffixIcon;
+
+  /// Clear icon in the text field, if onClear is null, this will not appear
+  final Widget clearIcon;
+
+  /// If this is set, it will be called when the clear button is tapped, if this is null there won't be a clear icon
+  final Function? onClear;
+
+  /// Set a custom on tap event for the filter suffix icon
+  final Function(
+    FocusNode focusNode,
+    TextEditingController controller,
+    bool enabled,
+    void Function(String changed) handleOnChanged,
+    PlutoGridStateManager stateManager,
+  )? onFilterSuffixTap;
+
+  final Widget Function(
+    FocusNode focusNode,
+    TextEditingController controller,
+    bool enabled,
+    void Function(String changed) handleOnChanged,
+    PlutoGridStateManager stateManager,
+  )? filterWidgetBuilder;
 }
 
 class PlutoColumnRendererContext {

--- a/lib/src/ui/columns/pluto_column_filter.dart
+++ b/lib/src/ui/columns/pluto_column_filter.dart
@@ -267,7 +267,20 @@ class PlutoColumnFilterState extends PlutoStateWithChange<PlutoColumnFilter> {
                 onChanged: _handleOnChanged,
                 onEditingComplete: _handleOnEditingComplete,
                 decoration: InputDecoration(
-                  suffixIcon: widget.column.filterSuffixIcon,
+                  suffixIcon: widget.column.filterSuffixIcon != null
+                      ? GestureDetector(
+                          onTap: () {
+                            widget.column.onFilterSuffixTap?.call(
+                              _focusNode,
+                              _controller,
+                              _enabled,
+                              _handleOnChanged,
+                              stateManager,
+                            );
+                          },
+                          child: widget.column.filterSuffixIcon,
+                        )
+                      : null,
                   hintText: widget.column.filterHintText ??
                       (_enabled ? widget.column.defaultFilter.title : ''),
                   filled: true,

--- a/lib/src/ui/columns/pluto_column_filter.dart
+++ b/lib/src/ui/columns/pluto_column_filter.dart
@@ -241,6 +241,50 @@ class PlutoColumnFilterState extends PlutoStateWithChange<PlutoColumnFilter> {
   @override
   Widget build(BuildContext context) {
     final style = stateManager.style;
+    final filterDelegate = widget.column.filterWidgetDelegate;
+
+    Widget? suffixIcon;
+
+    if (filterDelegate?.filterSuffixIcon != null) {
+      suffixIcon = InkWell(
+        onTap: () {
+          filterDelegate?.onFilterSuffixTap?.call(
+            _focusNode,
+            _controller,
+            _enabled,
+            _handleOnChanged,
+            stateManager,
+          );
+        },
+        child: filterDelegate?.filterSuffixIcon,
+      );
+    }
+
+    final clearIcon = InkWell(
+      onTap: () {
+        _controller.clear();
+        _handleOnChanged(_controller.text);
+        filterDelegate?.onClear?.call();
+      },
+      child: filterDelegate?.clearIcon,
+    );
+
+    if (filterDelegate?.onClear != null) {
+      if (suffixIcon == null) {
+        suffixIcon = clearIcon;
+      } else {
+        suffixIcon = Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          spacing: 8,
+          children: [
+            suffixIcon,
+            clearIcon,
+            SizedBox(width: 4),
+          ],
+        );
+      }
+    }
 
     return SizedBox(
       height: stateManager.columnFilterHeight,
@@ -255,9 +299,8 @@ class PlutoColumnFilterState extends PlutoStateWithChange<PlutoColumnFilter> {
         ),
         child: Padding(
           padding: _padding,
-          child: widget.column.filterWidget ??
-              widget.column.filterWidgetBuilder?.call(_focusNode, _controller,
-                  _enabled, _handleOnChanged, stateManager) ??
+          child: filterDelegate?.filterWidgetBuilder?.call(_focusNode,
+                  _controller, _enabled, _handleOnChanged, stateManager) ??
               TextField(
                 focusNode: _focusNode,
                 controller: _controller,
@@ -267,25 +310,12 @@ class PlutoColumnFilterState extends PlutoStateWithChange<PlutoColumnFilter> {
                 onChanged: _handleOnChanged,
                 onEditingComplete: _handleOnEditingComplete,
                 decoration: InputDecoration(
-                  suffixIcon: widget.column.filterSuffixIcon != null
-                      ? GestureDetector(
-                          onTap: () {
-                            widget.column.onFilterSuffixTap?.call(
-                              _focusNode,
-                              _controller,
-                              _enabled,
-                              _handleOnChanged,
-                              stateManager,
-                            );
-                          },
-                          child: widget.column.filterSuffixIcon,
-                        )
-                      : null,
-                  hintText: widget.column.filterHintText ??
+                  suffixIcon: suffixIcon,
+                  hintText: filterDelegate?.filterHintText ??
                       (_enabled ? widget.column.defaultFilter.title : ''),
                   filled: true,
                   hintStyle:
-                      TextStyle(color: widget.column.filterHintTextColor),
+                      TextStyle(color: filterDelegate?.filterHintTextColor),
                   fillColor: _textFieldColor,
                   border: _border,
                   enabledBorder: _border,


### PR DESCRIPTION
This fixes: https://github.com/doonfrs/pluto_grid_plus/issues/121

This adds:

- Missing parameter: **filterWidgetBuilder** added to customize a pluto column filter.
- Added clearIcon and onClear, if onClear is used then a clear icon shows in the textfield
- Added filterWidgetDelegate, the filterWidgetDelegate is a delegate that has 2 contrcutors.
```dart
  /// This is the default filter widget delegate
  const PlutoFilterColumnWidgetDelegate.textField({
    this.filterHintText,
    this.filterHintTextColor,
    this.filterSuffixIcon,
    this.onFilterSuffixTap,
    this.clearIcon = const Icon(Icons.clear),
    this.onClear,
  }) : filterWidgetBuilder = null;

  /// If you don't want a custom widget
  const PlutoFilterColumnWidgetDelegate.builder({
    this.filterWidgetBuilder,
  })  : filterSuffixIcon = null,
        onFilterSuffixTap = null,
        filterHintText = null,
        filterHintTextColor = null,
        clearIcon = const Icon(Icons.clear),
        onClear = null;
```

Those parameters are removed from the PlutoColumn class and replaced by a filterWidgetDelegate.